### PR TITLE
Guillaumefay/ss 1157 add monitoring to the published template

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,9 @@
 homepage: "https://www.gorgias.com/"
 documentation: "https://docs.gorgias.com/gorgias-chat/chat-getting-started#setup_instructions_for_google_tag_manager"
 versions:
+  # Latest version
+  - sha: 06a693c9c26f7ce8fa4c6f3e483b5f00d90aab09
+    changeNotes: Add the containerId as query param to the bundle loader URL
+  # Older version
   - sha: c257498038d265ef05274c7348a8f66afcdcd6cc
     changeNotes: Initial release.

--- a/template.tpl
+++ b/template.tpl
@@ -44,8 +44,10 @@ ___SANDBOXED_JS_FOR_WEB_TEMPLATE___
 const log = require('logToConsole');
 const injectScript = require('injectScript');
 const encodeUriComponent = require('encodeUriComponent');
+const getContainerVersion = require('getContainerVersion');
 
-const chatBundleLoaderUrl = 'https://config.gorgias.chat/gorgias-chat-bundle-loader.js?applicationId=' + encodeUriComponent(data.gorgiasChatAppID);
+const containerId = getContainerVersion().containerId;
+const chatBundleLoaderUrl = 'https://config.gorgias.chat/gorgias-chat-bundle-loader.js?applicationId=' + encodeUriComponent(data.gorgiasChatAppID) + '&GTMContainerId=' + encodeUriComponent(containerId);
 
 const onSuccess = () => {
   log('Gorgias chat : Successfully loaded');


### PR DESCRIPTION
#### Related Linear issue: <a href="https://linear.app/gorgias/issue/SS-1157/add-monitoring-to-the-published-template">SS-1157</a>

#### Changes:
- Add the container_id as query param to the bundle loader URL. This param will be used to monitor the customer's usage of GTM